### PR TITLE
Fix bug: `questions.rb` always selects the 1st row of CSV

### DIFF
--- a/questions.rb
+++ b/questions.rb
@@ -29,7 +29,7 @@ end
 index_of_max = similarity_array.index(similarity_array.max)
 original_text = ""
 
-CSV.foreach("embeddings.csv", headers: true).with_index(index_of_max) do |row, rowno|
+CSV.foreach("embeddings.csv", headers: true).with_index do |row, rowno|
   if rowno == index_of_max
     original_text = row['text']
   end


### PR DESCRIPTION
Hi, I read [this article](https://kanehooper.hashnode.dev/creating-an-intelligent-knowledge-base-qa-app-with-gpt-3-and-ruby), and it's very interesting to me!

I tried the same approach by forking this repository, then found that the `questions.rb` always selects the 1st row of `embeddings.csv` (to be precise, it's 2nd row since the 1st is headers.).

The cause is it gives `with_index` `index_of_max`. The loop starts with `rowno == index_of_max` so that the loop ends at the first time.